### PR TITLE
Respond with 301 for old path structures; fixes ocaml/opam2web#87

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -29,6 +29,16 @@ server {
   # This can also go in the http { } level
   index index.html;
 
+  location /pkg {
+    error_page 404 = @missing_pkg_page;
+  }
+
+  location @missing_pkg_page {
+    rewrite ^/pkg/((?U).*)/\1.(.*) /packages/$1/$1.$2 permanent;
+    rewrite ^/pkg/((?U).*)/(.*)    /packages/$1/$1.$2 permanent;
+    rewrite ^/pkg(.*)              /packages$1 permanent;
+  }
+
   location / {
     # if you're just using wordpress and don't want extra rewrites
     # then replace the word @rewrites with /index.php


### PR DESCRIPTION
This should be applied simultaneously with opam2web 1.3.0
